### PR TITLE
fix ci version-check

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Run tests
       run: cargo test
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -43,15 +43,21 @@ jobs:
       - name: Get previous version
         id: previous_version
         run: |
-          git fetch origin master
-          git show origin/master:Cargo.toml > Cargo.master.toml
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/master" ]]; then
+            git fetch origin ${{ github.event.before }}
+            git show ${{ github.event.before }}:Cargo.toml > Cargo.master.toml
+          else
+            git fetch origin master
+            git show origin/master:Cargo.toml > Cargo.master.toml
+          fi
+
           echo ::set-output name=version::$(grep -Po '^version = "\K[^"]+' Cargo.master.toml)
 
       - name: Check version
         id: check_version
         run: |
           python .github/version_check.py ${{ steps.previous_version.outputs.version }} ${{ steps.new_version.outputs.version }}
-          echo "${{ github.event_name}} ${{ github.ref }}"
+          echo "${{ github.event_name }} ${{ github.ref }}"
 
   build_and_release:
     needs: version-check
@@ -60,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Extract version from Cargo.toml
       id: version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "somo"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clap",
  "inquire",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "somo"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 authors = ["theopfr"]
 description = "A human-friendly alternative to netstat for socket and port monitoring on Linux."


### PR DESCRIPTION
Hopefully this fixes the version check. The goal is the following:

When a PR to ``master`` is created or updated, check that the version was bumped and also correctly bumped (eg. from ``1.3.0`` to ``1.3.5`` not allowed, must be incremental). To do so, compare the updated version inside ``Cargo.toml`` with the version inside ``Cargo.toml`` of ``master`` by checking out the ``master`` branch inside the CI.

When the PR is merged to ``master`` or a push to ``master`` happens, we can't checkout ``master`` to get the previous version because it will already be updated with the new version, as the CI checks run after the actual merge commit happens. Therefore use ``github.event.before`` to get the state of the branch before the merge commit.