### PR TITLE
Implement new CLI arguments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,8 @@ use crate::utils;
 pub struct Flags {
     pub kill: bool,
     pub proto: Option<String>,
+    pub tcp: bool,
+    pub udp: bool,
     pub ip: Option<String>,
     pub remote_port: Option<String>,
     pub port: Option<String>,
@@ -31,8 +33,15 @@ struct Args {
     #[arg(short = 'k', long, default_value = None)]
     kill: bool,
 
+    /// Deprecated. Use '--tcp' and '--udp' instead.
     #[arg(long, default_value = None)]
     proto: Option<String>,
+
+    #[arg(short, long, default_value = None)]
+    tcp: bool,
+
+    #[arg(short, long, default_value = None)]
+    udp: bool,
 
     #[arg(long, default_value = None)]
     ip: Option<String>,
@@ -78,6 +87,8 @@ pub fn cli() -> Flags {
     Flags {
         kill: args.kill,
         proto: args.proto,
+        tcp: args.tcp,
+        udp: args.udp,
         ip: args.ip,
         program: args.program,
         remote_port: args.remote_port,
@@ -147,6 +158,8 @@ mod tests {
             "-k",
             "--proto",
             "udp",
+            "--tcp",
+            "--udp",
             "--ip",
             "192.168.0.1",
             "--remote-port",
@@ -164,6 +177,8 @@ mod tests {
 
         assert!(args.kill);
         assert_eq!(args.proto.as_deref(), Some("udp"));
+        assert!(args.tcp);
+        assert!(args.udp);
         assert_eq!(args.ip.as_deref(), Some("192.168.0.1"));
         assert_eq!(args.remote_port.as_deref(), Some("53"));
         assert_eq!(args.port.as_deref(), Some("8080"));
@@ -180,6 +195,8 @@ mod tests {
 
         assert!(!args.kill);
         assert!(args.proto.is_none());
+        assert!(!args.tcp);
+        assert!(!args.udp);
         assert!(args.ip.is_none());
         assert!(args.remote_port.is_none());
         assert!(args.port.is_none());

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -219,14 +219,11 @@ pub fn get_all_connections(filter_options: &FilterOptions) -> Vec<Connection> {
     let all_processes = get_processes();
 
     let mut connections = Vec::new();
-
-    match filter_options.by_proto.as_deref() {
-        Some("tcp") => connections.extend(get_tcp_connections(&all_processes, filter_options)),
-        Some("udp") => connections.extend(get_udp_connections(&all_processes, filter_options)),
-        _ => {
-            connections.extend(get_tcp_connections(&all_processes, filter_options));
-            connections.extend(get_udp_connections(&all_processes, filter_options));
-        }
+    if filter_options.by_proto.tcp {
+        connections.extend(get_tcp_connections(&all_processes, filter_options))
+    }
+    if filter_options.by_proto.udp {
+        connections.extend(get_udp_connections(&all_processes, filter_options))
     }
 
     connections

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,37 +4,13 @@ mod schemas;
 mod table;
 mod utils;
 
-use schemas::{Connection, FilterOptions, Protocols};
-use utils::{TCP, UDP};
+use schemas::{Connection, FilterOptions};
 
 fn main() {
     let args: cli::Flags = cli::cli();
 
-    let proto = {
-        let mut proto = Protocols::default();
-        if args.tcp || args.udp {
-            proto.tcp = args.tcp;
-            proto.udp = args.udp;
-        } else if let Some(p) = args.proto {
-            // support the deprecated "--proto" argument
-            match p.to_lowercase().as_str() {
-                TCP => {
-                    proto.tcp = true;
-                }
-                UDP => {
-                    proto.udp = true;
-                }
-                _ => {}
-            }
-        } else {
-            // if neither is set, use both
-            proto.tcp = true;
-            proto.udp = true;
-        }
-        proto
-    };
     let filter_options: FilterOptions = FilterOptions {
-        by_proto: proto,
+        by_proto: utils::resolve_protocols(&args),
         by_remote_address: args.ip,
         by_remote_port: args.remote_port,
         by_local_port: args.port,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     };
 
     let filter_options: FilterOptions = FilterOptions {
-        by_proto: utils::resolve_protocols(&args),
+        by_proto: cli::resolve_protocols(&args),
         by_remote_address: args.ip,
         by_remote_port: args.remote_port,
         by_local_port: args.port,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,14 +12,11 @@ fn main() {
 
     let proto = {
         let mut proto = Protocols::default();
-        if args.tcp {
-            proto.tcp = true;
-        }
-        if args.udp {
-            proto.udp = true;
-        }
-        // support the deprecated "--proto" argument
-        if let Some(p) = args.proto {
+        if args.tcp || args.udp {
+            proto.tcp = args.tcp;
+            proto.udp = args.udp;
+        } else if let Some(p) = args.proto {
+            // support the deprecated "--proto" argument
             match p.to_lowercase().as_str() {
                 TCP => {
                     proto.tcp = true;
@@ -29,9 +26,8 @@ fn main() {
                 }
                 _ => {}
             }
-        }
-        // if neither is set, use both
-        if !proto.tcp && !proto.udp {
+        } else {
+            // if neither is set, use both
             proto.tcp = true;
             proto.udp = true;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,41 @@ mod schemas;
 mod table;
 mod utils;
 
-use schemas::Connection;
-use schemas::FilterOptions;
+use schemas::{Connection, FilterOptions, Protocols};
+use utils::{TCP, UDP};
 
 fn main() {
     let args: cli::Flags = cli::cli();
 
+    let proto = {
+        let mut proto = Protocols::default();
+        if args.tcp {
+            proto.tcp = true;
+        }
+        if args.udp {
+            proto.udp = true;
+        }
+        // support the deprecated "--proto" argument
+        if let Some(p) = args.proto {
+            match p.to_lowercase().as_str() {
+                TCP => {
+                    proto.tcp = true;
+                }
+                UDP => {
+                    proto.udp = true;
+                }
+                _ => {}
+            }
+        }
+        // if neither is set, use both
+        if !proto.tcp && !proto.udp {
+            proto.tcp = true;
+            proto.udp = true;
+        }
+        proto
+    };
     let filter_options: FilterOptions = FilterOptions {
-        by_proto: args.proto,
+        by_proto: proto,
         by_remote_address: args.ip,
         by_remote_port: args.remote_port,
         by_local_port: args.port,

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -13,6 +13,13 @@ pub enum AddressType {
     Extern,
 }
 
+/// Contains which type(s) of protocols the user wants to see.
+#[derive(Debug, Default)]
+pub struct Protocols {
+    pub tcp: bool,
+    pub udp: bool,
+}
+
 /// Represents a processed socket connection with all its attributes.
 #[derive(Debug, serde::Serialize)]
 pub struct Connection {
@@ -39,7 +46,7 @@ pub struct NetEntry {
 /// Contains options for filtering a `Conntection`.
 #[derive(Debug, Default)]
 pub struct FilterOptions {
-    pub by_proto: Option<String>,
+    pub by_proto: Protocols,
     pub by_program: Option<String>,
     pub by_pid: Option<String>,
     pub by_remote_address: Option<String>,

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -56,3 +56,21 @@ pub struct FilterOptions {
     pub by_listen: bool,
     pub exclude_ipv6: bool,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Protocol {
+    Tcp,
+    Udp,
+}
+
+impl std::str::FromStr for Protocol {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input.to_lowercase().as_str() {
+            "tcp" => Ok(Protocol::Tcp),
+            "udp" => Ok(Protocol::Udp),
+            _ => Err(()),
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,3 @@
-use std::str::FromStr;
-
-use crate::{
-    cli::Flags,
-    schemas::{Protocol, Protocols},
-};
 use termimad::crossterm::style::{Attribute::*, Color::*};
 use termimad::*;
 
@@ -99,28 +93,6 @@ pub fn pretty_print_error(text: &str) {
 
     let markdown: String = format!("~~Error~~: *{}*", text);
     print!("{}", skin.term_text(&markdown));
-}
-
-/// Parse the CLI arguments to determine which protocols to filter to.
-pub fn resolve_protocols(args: &Flags) -> Protocols {
-    let mut protocols = Protocols::default();
-    if args.tcp || args.udp {
-        protocols.tcp = args.tcp;
-        protocols.udp = args.udp;
-    } else if let Some(arg) = &args.proto {
-        // support the deprecated "--proto" argument
-        if let Ok(matching) = Protocol::from_str(arg) {
-            match matching {
-                Protocol::Tcp => protocols.tcp = true,
-                Protocol::Udp => protocols.udp = true,
-            }
-        }
-    } else {
-        // if neither is set, use both
-        protocols.tcp = true;
-        protocols.udp = true;
-    }
-    protocols
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,9 @@
 use termimad::crossterm::style::{Attribute::*, Color::*};
 use termimad::*;
 
+pub const UDP: &str = "udp";
+pub const TCP: &str = "tcp";
+
 /// Splits a string combined of an IP address and port with a ":" delimiter into two parts.
 ///
 /// # Arguments

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,11 @@
+use std::str::FromStr;
+
+use crate::{
+    cli::Flags,
+    schemas::{Protocol, Protocols},
+};
 use termimad::crossterm::style::{Attribute::*, Color::*};
 use termimad::*;
-
-pub const UDP: &str = "udp";
-pub const TCP: &str = "tcp";
 
 /// Splits a string combined of an IP address and port with a ":" delimiter into two parts.
 ///
@@ -95,6 +98,28 @@ pub fn pretty_print_error(text: &str) {
 
     let markdown: String = format!("~~Error~~: *{}*", text);
     print!("{}", skin.term_text(&markdown));
+}
+
+/// Parse the CLI arguments to determine which protocols to filter to.
+pub fn resolve_protocols(args: &Flags) -> Protocols {
+    let mut protocols = Protocols::default();
+    if args.tcp || args.udp {
+        protocols.tcp = args.tcp;
+        protocols.udp = args.udp;
+    } else if let Some(arg) = &args.proto {
+        // support the deprecated "--proto" argument
+        if let Ok(matching) = Protocol::from_str(arg) {
+            match matching {
+                Protocol::Tcp => protocols.tcp = true,
+                Protocol::Udp => protocols.udp = true,
+            }
+        }
+    } else {
+        // if neither is set, use both
+        protocols.tcp = true;
+        protocols.udp = true;
+    }
+    protocols
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #31

`--help` output now looks like this:

```plain
A human-friendly alternative to netstat for socket and port monitoring on Linux.

Usage: somo [OPTIONS] [COMMAND]

Commands:
  generate-completions  Generate shell completions
  help                  Print this message or the help of the given subcommand(s)

Options:
  -k, --kill                       Display an interactive selection option after inspecting connections
      --proto <PROTO>              Deprecated. Use '--tcp' and '--udp' instead
  -t, --tcp                        Include TCP connections
  -u, --udp                        Include UDP connections
      --ip <IP>                    Filter connections by remote IP address
      --remote-port <REMOTE_PORT>  Filter connections by remote port
  -p, --port <PORT>                Filter connections by local port
      --program <PROGRAM>          Filter connections by program name
      --pid <PID>                  Filter connections by PID
      --format <FORMAT>            Format the output in a certain way, e.g., `somo --format "PID: {{pid}}, Protocol: {{proto}}, Remote Address: {{remote_address}}"`
      --json                       Output in JSON
  -o, --open                       Filter by open connections
  -l, --listen                     Filter by listening connections
      --exclude-ipv6               Exclude IPv6 connections
  -h, --help                       Print help
  -V, --version                    Print version
```

I think everything else works as intended - the user can specify `--tcp` (`-t`) or `--udp` (`-u`) to filter to those protocols, can set both, if neither are set both are shown, and the `--proto` argument is still supported.