### PR TITLE
gracefully handled pipes in existing cases; fixes #34

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -1,6 +1,7 @@
 use handlebars::Handlebars;
 use termimad::crossterm::style::{Attribute::*, Color::*};
 use termimad::*;
+use std::io::{Write};
 
 use crate::schemas::{AddressType, Connection};
 use crate::utils;
@@ -143,9 +144,11 @@ pub fn print_connections_table(all_connections: &[Connection], use_compact_mode:
 
     markdown.push_str(CENTER_MARKDOWN_ROW);
 
-    println!("{}", skin.term_text(&markdown));
-
-    utils::pretty_print_info(&format!("**{} Connections**", all_connections.len()));
+    match writeln!(std::io::stdout(), "{}", skin.term_text(&markdown)) {
+        Ok(_) => utils::pretty_print_info(&format!("**{} Connections**", all_connections.len())),
+        Err(broken_pipe) if broken_pipe.kind() == std::io::ErrorKind::BrokenPipe => (),
+        Err(err) => panic!("Unknown error occured while writing to stdout {:?}", err.kind()),
+    }
 }
 
 /// Prints all current connections in a json format.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use termimad::crossterm::style::{Attribute::*, Color::*};
 use termimad::*;
+use std::io::{self, Write};
 
 /// Splits a string combined of an IP address and port with a ":" delimiter into two parts.
 ///
@@ -70,7 +71,11 @@ pub fn pretty_print_info(text: &str) {
     skin.strikeout = CompoundStyle::new(Some(Cyan), None, Encircled.into());
 
     let markdown: String = format!("~~Info~~: *{}*", text);
-    print!("{}", skin.term_text(&markdown));
+    match writeln!(io::stdout(), "{}", skin.term_text(&markdown)) {
+        Ok(_) => (),
+        Err(broken_pipe) if broken_pipe.kind() == io::ErrorKind::BrokenPipe => (),
+        Err(err) => panic!("Unknown error occured while writing to stdout {:?}", err.kind()),
+    }
 }
 
 /// Prints out Markdown formatted text using a custom appearance / termimad "skin".
@@ -92,7 +97,11 @@ pub fn pretty_print_error(text: &str) {
     skin.strikeout = CompoundStyle::new(Some(Red), None, Encircled.into());
 
     let markdown: String = format!("~~Error~~: *{}*", text);
-    print!("{}", skin.term_text(&markdown));
+    match writeln!(io::stdout(), "{}", skin.term_text(&markdown)) {
+        Ok(_) => (),
+        Err(broken_pipe) if broken_pipe.kind() == io::ErrorKind::BrokenPipe => (),
+        Err(err) => panic!("Unknown error occured while writing to stdout {:?}", err.kind()),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
https://users.rust-lang.org/t/why-does-the-pipe-cause-the-panic-in-the-standard-library/107222/4 https://github.com/rust-lang/rust/issues/97889

unfortunately the appropriate rustlang feature is still experimental; in reality, the most convenient handling should be done by rustlang itself, since this is a fragile case-by-case basis.

in order for this approach to be correct throughout, all `println!` macros should be replaced with the appropriate `writeln!` handling; admittedly, this is too invasive for such a minor issue, so I handled the appropriate cases by hand.

fixes #34, along with the extra case mentioned in the issue when using the `--kill` flag while paged.