### PR TITLE
Add shell completions in Nix package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@21a544727d0c62386e78b4befe52d19ad12692e3 # v17
       - run: nix run 'path:.?dir=nix'
+      - run: nix build 'path:.?dir=nix'
+      - run: tree ./result

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,6 +1,8 @@
 {
   lib,
+  stdenv,
   rustPlatform,
+  installShellFiles,
   versionCheckHook,
 }:
 
@@ -21,6 +23,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd ${mainProgram} \
+      --bash <("$out/bin/${mainProgram}" generate-completions bash) \
+      --zsh <("$out/bin/${mainProgram}" generate-completions zsh) \
+      --fish <("$out/bin/${mainProgram}" generate-completions fish)
+  '';
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Follow #24 in package.nix. Shell completions belong in ./result/share/.

- Typically, package.nix only includes completions for Bash, Zsh, and Fish. Therefore, Elvish and PowerShell completions were omitted here.
- `stdenv.buildPlatform.canExecute stdenv.hostPlatform` is a common idiom for this scenario. For details, see https://github.com/NixOS/nixpkgs/blob/618b6dbfc21097d3101f3fc23e6597a2621eb04e/doc/hooks/installShellFiles.section.md?plain=1#L87-L110.

After this change.

```console
> tree ./result/
./result/
├── bin
│   └── somo
└── share
    ├── bash-completion
    │   └── completions
    │       └── somo.bash
    ├── fish
    │   └── vendor_completions.d
    │       └── somo.fish
    └── zsh
        └── site-functions
            └── _somo

9 directories, 4 files
```

The added `nix build` GHA step is fast, as its result is cached in the `nix run` step.

![image](https://github.com/user-attachments/assets/df712f25-6c4f-4cab-a270-6772d72a1dc7)
