### PR TITLE
sorting by column, closes #30

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,24 +98,13 @@ pub struct Args {
     #[arg(short = 'c', long, default_value_t = false)]
     compact: bool,
 
-    #[command(flatten)]
-    sorting_args: Option<SortingArgs>,
-}
-
-//  For future reference since this isn't terribly well documented,
-//   a mutually exclusive group would be defined with optional arguments with
-//   the group derivation
-//   #[group(multiple=true)]
-/// Mutually inclusive group of arguments regarding sorting of values.
-#[derive(clap::Args, Debug)]
-pub struct SortingArgs {
-    /// Sort in reverse.
+    /// Reverse order of the table
     #[arg(short = 'r', long, default_value_t = false)]
     reverse: bool,
 
     /// Sort by <column name>.
     #[arg(short = 's', long, default_value = None)]
-    sort: SortField,
+    sort: Option<SortField>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -172,21 +161,13 @@ pub fn cli() -> CliCommand {
             listen: args.listen,
             exclude_ipv6: args.exclude_ipv6,
             compact: args.compact,
-            sort: if args.sorting_args.is_some() {
-                Some(args.sorting_args.as_ref().unwrap().sort)
-            } else {
-                None
-            },
-            reverse: if args.sorting_args.is_some() {
-                args.sorting_args.as_ref().unwrap().reverse
-            } else {
-                false
-            },
+            sort: args.sort,
+            reverse: args.reverse,
         }),
     }
 }
 
-pub fn sort_connections_via_key(all_connections: &mut [Connection], field: SortField) {
+pub fn sort_connections(all_connections: &mut [Connection], field: SortField) {
     all_connections.sort_by(|our, other| match field {
         SortField::Proto => our.proto.to_lowercase().cmp(&other.proto.to_lowercase()),
         SortField::LocalPort => our

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -112,7 +112,7 @@ pub struct SortingArgs {
     #[arg(long, default_value = None)]
     sort_order: Option<SortOrder>,
 
-    /// Sort by <column name>, provided an order
+    /// Sort by <column name>.
     #[arg(long, default_value = None)]
     sort_by: SortField,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,9 +108,11 @@ pub struct Args {
 /// Mutually inclusive group of arguments regarding sorting of values.
 #[derive(clap::Args, Debug)]
 pub struct SortingArgs {
-    /// Sort by column ascending <column name>
+    /// Sort by order <ascending/descending>, provided a <column name>
     #[arg(long, default_value = None)]
     sort_order: SortOrder,
+
+    /// Sort by <column name>, provided an order
     #[arg(long, default_value = None)]
     sort_field: SortField,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,7 +194,7 @@ pub fn sort_connections_via_key(all_connections: &mut [Connection], field: SortF
             .parse::<u32>()
             .unwrap()
             .cmp(&other.local_port.parse::<u32>().unwrap()),
-        SortField::RemoteAddress => todo!(),
+        SortField::RemoteAddress => our.ipvx_raw.cmp(&other.ipvx_raw),
         SortField::RemotePort => our
             .remote_port
             .parse::<u32>()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,8 +28,8 @@ pub struct Flags {
     pub listen: bool,
     pub exclude_ipv6: bool,
     pub compact: bool,
-    pub sort_by: Option<SortField>,
-    pub reverse_sorted: bool,
+    pub sort: Option<SortField>,
+    pub reverse: bool,
 }
 
 /// Represents all possible flags which can be provided by the user in the CLI.
@@ -172,12 +172,12 @@ pub fn cli() -> CliCommand {
             listen: args.listen,
             exclude_ipv6: args.exclude_ipv6,
             compact: args.compact,
-            sort_by: if args.sorting_args.is_some() {
+            sort: if args.sorting_args.is_some() {
                 Some(args.sorting_args.as_ref().unwrap().sort)
             } else {
                 None
             },
-            reverse_sorted: if args.sorting_args.is_some() {
+            reverse: if args.sorting_args.is_some() {
                 args.sorting_args.as_ref().unwrap().reverse
             } else {
                 false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,11 +110,11 @@ pub struct Args {
 #[derive(clap::Args, Debug)]
 pub struct SortingArgs {
     /// Sort in reverse.
-    #[arg(long, default_value_t = false, visible_alias = "re")]
+    #[arg(short = 'r', long, default_value_t = false)]
     reverse: bool,
 
     /// Sort by <column name>.
-    #[arg(long, default_value = None, visible_alias = "sb")]
+    #[arg(short = 's', long, default_value = None)]
     sort: SortField,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,13 +108,13 @@ pub struct Args {
 /// Mutually inclusive group of arguments regarding sorting of values.
 #[derive(clap::Args, Debug)]
 pub struct SortingArgs {
-    /// Sort by order <ascending/descending>, provided a <column name>
+    /// Sort by order <ascending/descending>, provided a <column name>. Defaults to ascending.
     #[arg(long, default_value = None)]
-    sort_order: SortOrder,
+    sort_order: Option<SortOrder>,
 
     /// Sort by <column name>, provided an order
     #[arg(long, default_value = None)]
-    sort_field: SortField,
+    sort_by: SortField,
 }
 
 #[derive(Subcommand, Debug)]
@@ -182,8 +182,12 @@ pub fn cli() -> CliCommand {
             sort: args.sorting_args.is_some().then(|| {
                 (
                     // tuple
-                    args.sorting_args.as_ref().unwrap().sort_order,
-                    args.sorting_args.as_ref().unwrap().sort_field,
+                    args.sorting_args
+                        .as_ref()
+                        .unwrap()
+                        .sort_order
+                        .unwrap_or(SortOrder::Ascending),
+                    args.sorting_args.as_ref().unwrap().sort_by,
                 )
             }),
         }),

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -232,6 +232,8 @@ pub fn get_all_connections(filter_options: &FilterOptions) -> Vec<Connection> {
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use super::*;
 
     #[test]
@@ -258,6 +260,7 @@ mod tests {
             pid: "123".to_string(),
             state: "established".to_string(),
             address_type: AddressType::Extern,
+            ipvx_raw: Ipv4Addr::new(8, 8, 8, 8).into(),
         };
 
         let filter_by_matching_port = FilterOptions {
@@ -286,6 +289,7 @@ mod tests {
             pid: "123".to_string(),
             state: "close".to_string(),
             address_type: AddressType::Extern,
+            ipvx_raw: Ipv4Addr::new(8, 8, 8, 8).into(),
         };
 
         let filter_by_open_state = FilterOptions {
@@ -328,6 +332,7 @@ mod tests {
             pid: "123".to_string(),
             state: "close".to_string(),
             address_type: AddressType::Extern,
+            ipvx_raw: Ipv4Addr::new(8, 8, 8, 8).into(),
         };
 
         let filter_by_open_state = FilterOptions {
@@ -356,6 +361,7 @@ mod tests {
             pid: "123".to_string(),
             state: "listen".to_string(),
             address_type: AddressType::Extern,
+            ipvx_raw: Ipv4Addr::new(8, 8, 8, 8).into(),
         };
 
         let filter_by_multiple_conditions = FilterOptions {

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -124,6 +124,7 @@ fn get_connection_data(net_entry: NetEntry, all_processes: &HashMap<u64, Stat>) 
         pid,
         state,
         address_type,
+        ipvx_raw: net_entry.remote_address.ip(),
     };
 
     connection

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,11 +35,11 @@ fn main() {
 
     let mut all_connections: Vec<Connection> = connections::get_all_connections(&filter_options);
     // if we're instructed to sort in any way...
-    args.sort_by
+    args.sort
         .is_some()
-        .then(|| sort_connections_via_key(&mut all_connections, args.sort_by.unwrap()));
+        .then(|| sort_connections_via_key(&mut all_connections, args.sort.unwrap()));
 
-    if args.reverse_sorted {
+    if args.reverse {
         all_connections.reverse();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use clap::CommandFactory;
 use cli::{print_completions, Args, CliCommand, Commands};
 use schemas::{Connection, FilterOptions};
 
-use crate::cli::sort_connections_via_key;
+use crate::cli::sort_connections;
 
 fn main() {
     let args = match cli::cli() {
@@ -37,7 +37,7 @@ fn main() {
     // if we're instructed to sort in any way...
     args.sort
         .is_some()
-        .then(|| sort_connections_via_key(&mut all_connections, args.sort.unwrap()));
+        .then(|| sort_connections(&mut all_connections, args.sort.unwrap()));
 
     if args.reverse {
         all_connections.reverse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,10 +34,10 @@ fn main() {
     };
 
     let mut all_connections: Vec<Connection> = connections::get_all_connections(&filter_options);
-    // if we're instructed to sort in any way...
-    args.sort
-        .is_some()
-        .then(|| sort_connections(&mut all_connections, args.sort.unwrap()));
+
+    if let Some(sort) = args.sort {
+        sort_connections(&mut all_connections, sort);
+    }
 
     if args.reverse {
         all_connections.reverse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ use clap::CommandFactory;
 use cli::{print_completions, Args, CliCommand, Commands};
 use schemas::{Connection, FilterOptions};
 
+use crate::cli::KeySortable;
+
 fn main() {
     let args = match cli::cli() {
         CliCommand::Subcommand(Commands::GenerateCompletions { shell }) => {
@@ -31,7 +33,12 @@ fn main() {
         exclude_ipv6: args.exclude_ipv6,
     };
 
-    let all_connections: Vec<Connection> = connections::get_all_connections(&filter_options);
+    let mut all_connections: Vec<Connection> = connections::get_all_connections(&filter_options);
+    args.sort.is_some().then(|| {
+        all_connections.sort_by_key(
+            |k| k.sortable_by(args.sort.unwrap().0, args.sort.unwrap().1)
+        )
+    });
 
     if args.json {
         let result = table::get_connections_json(&all_connections);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,7 @@ fn main() {
 
     let mut all_connections: Vec<Connection> = connections::get_all_connections(&filter_options);
     args.sort.is_some().then(|| {
-        all_connections.sort_by_key(
-            |k| k.sortable_by(args.sort.unwrap().0, args.sort.unwrap().1)
-        )
+        all_connections.sort_by_key(|k| k.sortable_by(args.sort.unwrap().0, args.sort.unwrap().1))
     });
 
     if args.json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use clap::CommandFactory;
 use cli::{print_completions, Args, CliCommand, Commands};
 use schemas::{Connection, FilterOptions};
 
-use crate::cli::sort_connections_via_order_and_key;
+use crate::cli::sort_connections_via_key;
 
 fn main() {
     let args = match cli::cli() {
@@ -35,13 +35,13 @@ fn main() {
 
     let mut all_connections: Vec<Connection> = connections::get_all_connections(&filter_options);
     // if we're instructed to sort in any way...
-    args.sort.is_some().then(|| {
-        sort_connections_via_order_and_key(
-            &mut all_connections,
-            args.sort.unwrap().0, // order
-            args.sort.unwrap().1, // key
-        )
-    });
+    args.sort_by
+        .is_some()
+        .then(|| sort_connections_via_key(&mut all_connections, args.sort_by.unwrap()));
+
+    if args.reverse_sorted {
+        all_connections.reverse();
+    }
 
     if args.json {
         let result = table::get_connections_json(&all_connections);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use clap::CommandFactory;
 use cli::{print_completions, Args, CliCommand, Commands};
 use schemas::{Connection, FilterOptions};
 
-use crate::cli::KeySortable;
+use crate::cli::sort_connections_via_order_and_key;
 
 fn main() {
     let args = match cli::cli() {
@@ -34,8 +34,13 @@ fn main() {
     };
 
     let mut all_connections: Vec<Connection> = connections::get_all_connections(&filter_options);
+    // if we're instructed to sort in any way...
     args.sort.is_some().then(|| {
-        all_connections.sort_by_key(|k| k.sortable_by(args.sort.unwrap().0, args.sort.unwrap().1))
+        sort_connections_via_order_and_key(
+            &mut all_connections,
+            args.sort.unwrap().0, // order
+            args.sort.unwrap().1, // key
+        )
     });
 
     if args.json {

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -32,7 +32,7 @@ pub struct Connection {
     pub state: String,
     pub address_type: AddressType,
 
-    /// internal variable used only for ordering operations of raw ipv4/6 addresses
+    /// Internal variable used only for ordering operations of raw ipv4/6 addresses
     #[serde(skip_serializing)]
     pub ipvx_raw: IpAddr,
 }

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 /// Represents the type of an IP address.
 ///
@@ -31,6 +31,10 @@ pub struct Connection {
     pub pid: String,
     pub state: String,
     pub address_type: AddressType,
+
+    /// internal variable used only for ordering operations of raw ipv4/6 addresses
+    #[serde(skip_serializing)]
+    pub ipvx_raw: IpAddr,
 }
 
 /// General struct type for TCP and UDP entries.

--- a/src/table.rs
+++ b/src/table.rs
@@ -187,6 +187,8 @@ pub fn get_connections_formatted(
 
 #[cfg(test)]
 mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
     use super::*;
 
     #[test]
@@ -238,6 +240,7 @@ mod tests {
                 pid: "200".to_string(),
                 state: "established".to_string(),
                 address_type: AddressType::Localhost,
+                ipvx_raw: Ipv4Addr::new(192, 168, 1, 0).into(),
             },
             Connection {
                 proto: "tcp".to_string(),
@@ -248,6 +251,7 @@ mod tests {
                 pid: "-".to_string(),
                 state: "timewait".to_string(),
                 address_type: AddressType::Extern,
+                ipvx_raw: Ipv6Addr::new(0, 0, 0, 0xffff, 65, 9, 95, 5).into(),
             },
         ];
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -111,7 +111,6 @@ pub fn print_connections_table(all_connections: &[Connection], use_compact_mode:
     markdown.push_str("| **#** | **proto** | **local port** | **remote address** | **remote port** | **pid** *program* | **state** |\n");
     markdown.push_str(CENTER_MARKDOWN_ROW);
 
-    // iterate over all connections to build the table
     for (idx, connection) in all_connections.iter().enumerate() {
         let formatted_remote_address: String =
             format_known_address(&connection.remote_address, &connection.address_type);


### PR DESCRIPTION
implemented first (incomplete) draft of sorting by column.
Pending program name sorting & ipvX addresses.

This is currently a draft implementation of #30. 
Kindly asking for feedback regarding the approach since the implementation might be a little arcane on a first glance. I am attempting to provide a 'universal' way to sort the keys in relation to themselves. If there is a less arcane way of declaring order of Rust's driftsort, please tell me.
Documentation should be improved since it is currently lacking, please do provide pointers where.

Adds the following inclusive group of flags via derive clap API:
```
-r, --reverse                    Sort in reverse
-s, --sort <SORT>                Sort by <column name> [possible values: proto, local-port, remote-address, remote-port, program, pid, state]
```

Smoke tests also need to be added for the `KeySortable`'s `sortable_by` trait.
