### PR TITLE
added error handling for erroneous --format cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +441,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,16 +458,18 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.5.0"
+version = "6.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
+checksum = "759e2d5aea3287cb1190c8ec394f42866cb5bf74fcbf213f354e3c856ea26098"
 dependencies = [
+ "derive_builder",
  "log",
+ "num-order",
  "pest",
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 1.0.40",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -438,6 +512,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "inquire"
@@ -601,6 +681,21 @@ checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
+]
+
+[[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ termimad = "0.20"
 terminal_size = "0.2.6"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.96"
-handlebars = "4"
+handlebars = "6.3.2"
 nix = {version = "0.30.1", features = ["process", "signal"]}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,8 +244,8 @@ pub fn kill_process(pid_num: i32) {
     let pid = Pid::from_raw(pid_num);
 
     match signal::kill(pid, signal::Signal::SIGTERM) {
-        Ok(_) => utils::pretty_print_info(&format!("Killed process with PID {}.", pid)),
-        Err(_) => utils::pretty_print_error(&format!("Failed to kill process with PID {}.", pid)),
+        Ok(_) => utils::pretty_print_info(&format!("Killed process with PID {pid}.")),
+        Err(_) => utils::pretty_print_error(&format!("Failed to kill process with PID {pid}.")),
     }
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -58,10 +58,10 @@ fn create_table_style(use_compact_mode: bool) -> MadSkin {
 fn format_known_address(remote_address: &String, address_type: &AddressType) -> String {
     match address_type {
         AddressType::Unspecified => {
-            format!("*{}*", remote_address)
+            format!("*{remote_address}*")
         }
         AddressType::Localhost => {
-            format!("*{} localhost*", remote_address)
+            format!("*{remote_address} localhost*")
         }
         AddressType::Extern => remote_address.to_string(),
     }
@@ -197,7 +197,7 @@ pub fn get_connections_formatted(
             match err.reason() {
                 RenderErrorReason::MissingVariable(Some(var_name)) => {
                     pretty_print_syntax_error(
-                        &format!("Invalid template variable '{}'.", var_name),
+                        &format!("Invalid template variable '{var_name}'."),
                         template_string,
                         line_no,
                         column_no,

--- a/src/table.rs
+++ b/src/table.rs
@@ -3,7 +3,7 @@ use termimad::crossterm::style::{Attribute::*, Color::*};
 use termimad::*;
 
 use crate::schemas::{AddressType, Connection};
-use crate::utils::{pretty_print_error, pretty_print_syntax_error};
+use crate::utils::pretty_print_syntax_error;
 use crate::{soutln, utils};
 
 /// Uses the termimad crate to create a custom appearance for Markdown text in the console.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -97,7 +97,7 @@ pub fn pretty_print_error(text: &str) {
 }
 
 // template_segment is unfortunately NOT exposed in handlebars api :)
-pub fn pretty_single_line_syntax_error(preamble: &str, text: &str, column: usize) {
+pub fn pretty_print_syntax_error(preamble: &str, text: &str, column: usize) {
     let mut skin = MadSkin::default();
     skin.bold.set_fg(White);
     skin.italic = CompoundStyle::new(Some(gray(11)), None, Encircled.into());
@@ -105,8 +105,8 @@ pub fn pretty_single_line_syntax_error(preamble: &str, text: &str, column: usize
 
     let preamble_markdown: String = format!("~~Error~~: *{}*", preamble);
 
-    let indicator: String = format!("{}{}", "╌".repeat(column - 1), "┘");
-    let syntax_markdown: String = format!("{}\n*{}*", text, indicator);
+    let indicator: String = format!("{}{}", "─".repeat(column - 1), "┘");
+    let syntax_markdown: String = format!("*├────> {}*\n*└──────{}*", text, indicator);
     sout!("{}", skin.term_text(&preamble_markdown));
     sout!("{}", skin.term_text(&syntax_markdown));
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,4 @@
-use crate::{sout, soutln};
-use termimad::crossterm::style::{Attribute::*, Color::*};
-use termimad::*;
+use crate::soutln;
 
 /// Splits a string combined of an IP address and port with a ":" delimiter into two parts.
 ///
@@ -52,12 +50,22 @@ pub fn get_address_parts(address: &str) -> (String, String) {
         .unwrap_or((address.to_string(), "-".to_string()))
 }
 
-/// Prints out Markdown formatted text using a custom appearance / termimad "skin".
-///
-/// # Appearance
-/// * **bold** text -> bold and white
-/// * *italic* text -> not italic and gray
-/// * ~~strikeout~~ text -> not struck out and green
+/// Wraps the input text in ANSI escape codes to print it in red.
+fn red_text(text: &str) -> String {
+    format!("\x1b[1;31m{}\x1b[0m", text)
+}
+
+/// Wraps the input text in ANSI escape codes to print it in cyan.
+fn cyan_text(text: &str) -> String {
+    format!("\x1B[36m{}\x1B[0m", text)
+}
+
+/// Wraps the input text in ANSI escape codes to print it in bold.
+fn bold_text(text: &str) -> String {
+    format!("\x1B[1m{}\x1B[0m", text)
+}
+
+/// Prints out formatted text starting with a cyan "Info:" prefix.
 ///
 /// # Arguments
 /// * `text`: The text to print to the console.
@@ -65,21 +73,13 @@ pub fn get_address_parts(address: &str) -> (String, String) {
 /// # Returns
 /// None
 pub fn pretty_print_info(text: &str) {
-    let mut skin: MadSkin = MadSkin::default();
-    skin.bold.set_fg(White);
-    skin.italic = CompoundStyle::new(Some(gray(11)), None, Encircled.into());
-    skin.strikeout = CompoundStyle::new(Some(Cyan), None, Encircled.into());
-
-    let markdown: String = format!("~~Info~~: *{}*", text);
-    sout!("{}", skin.term_text(&markdown));
+    soutln!(
+        "{}",
+        bold_text(&format!("{} {}", cyan_text("Info:"), bold_text(text)))
+    );
 }
 
-/// Prints out Markdown formatted text using a custom appearance / termimad "skin".
-///
-/// # Appearance
-/// * **bold** text -> bold and white
-/// * *italic* text -> not italic and gray
-/// * ~~strikeout~~ text -> not struck out and red
+/// Prints out formatted text starting with a red "Error:" prefix.
 ///
 /// # Arguments
 /// * `text`: The text to print to the console.
@@ -87,33 +87,41 @@ pub fn pretty_print_info(text: &str) {
 /// # Returns
 /// None
 pub fn pretty_print_error(text: &str) {
-    let mut skin = MadSkin::default();
-    skin.bold.set_fg(White);
-    skin.italic = CompoundStyle::new(Some(gray(11)), None, Encircled.into());
-    skin.strikeout = CompoundStyle::new(Some(Red), None, Encircled.into());
-
-    let markdown: String = format!("~~Error~~: *{}*", text);
-    sout!("{}", skin.term_text(&markdown));
+    soutln!(
+        "{}",
+        bold_text(&format!("{} {}", red_text("Error:"), bold_text(text)))
+    );
 }
 
-// template_segment is unfortunately NOT exposed in handlebars api :)
-pub fn pretty_print_syntax_error(preamble: &str, text: &str, column: usize) {
-    let mut skin = MadSkin::default();
-    skin.bold.set_fg(White);
-    skin.italic = CompoundStyle::new(Some(gray(11)), None, Encircled.into());
-    skin.strikeout = CompoundStyle::new(Some(Red), None, Encircled.into());
+/// Prints a syntax error message with an error preamble, the error line, and
+/// a caret pointing to the error column.
+///
+/// # Arguments
+/// * `preamble`: The error message or description to print.
+/// * `text`: The full source text containing the error.
+/// * `line`: The line number (starting at 1) where the error occurred.
+/// * `column`: The column number (starting at 1) where the error occurred.
+///
+/// # Returns
+/// None
+///
+/// # Example
+/// ```
+/// let code = "let x = 5;\nlet y = 1o;";
+/// pretty_print_syntax_error("Unexpected token", code, 2, 9);
+/// ```
+pub fn pretty_print_syntax_error(preamble: &str, text: &str, line: usize, column: usize) {
+    let erronous_line: &str = text.lines().nth(line - 1).unwrap_or(text);
+    let line_pointer = "└─>";
 
-    let preamble_markdown: String = format!("~~Error~~: *{}*", preamble);
-
-    let indicator: String = format!("{}{}", "─".repeat(column - 1), "┘");
-    let mut syntax_skinned: String = skin.term_text("*├────> *").to_string();
-    syntax_skinned.pop(); // remove trailing newline from termimad
-    syntax_skinned.push_str(text);
-
-    let indicator_markdown: String = format!("*└──────{}*", indicator);
-    sout!("{}", skin.term_text(&preamble_markdown));
-    soutln!("{}", syntax_skinned);
-    sout!("{}", skin.term_text(&indicator_markdown));
+    pretty_print_error(preamble);
+    soutln!("  {}", red_text("│"));
+    soutln!("  {}  {}", red_text(line_pointer), erronous_line);
+    soutln!(
+        "  {}  {}",
+        " ".repeat(line_pointer.chars().count() + column - 1),
+        red_text("^")
+    );
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -96,6 +96,21 @@ pub fn pretty_print_error(text: &str) {
     sout!("{}", skin.term_text(&markdown));
 }
 
+// template_segment is unfortunately NOT exposed in handlebars api :)
+pub fn pretty_single_line_syntax_error(preamble: &str, text: &str, column: usize) {
+    let mut skin = MadSkin::default();
+    skin.bold.set_fg(White);
+    skin.italic = CompoundStyle::new(Some(gray(11)), None, Encircled.into());
+    skin.strikeout = CompoundStyle::new(Some(Red), None, Encircled.into());
+
+    let preamble_markdown: String = format!("~~Error~~: *{}*", preamble);
+
+    let indicator: String = format!("{}{}", "╌".repeat(column - 1), "┘");
+    let syntax_markdown: String = format!("{}\n*{}*", text, indicator);
+    sout!("{}", skin.term_text(&preamble_markdown));
+    sout!("{}", skin.term_text(&syntax_markdown));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::sout;
+use crate::{sout, soutln};
 use termimad::crossterm::style::{Attribute::*, Color::*};
 use termimad::*;
 
@@ -106,9 +106,14 @@ pub fn pretty_print_syntax_error(preamble: &str, text: &str, column: usize) {
     let preamble_markdown: String = format!("~~Error~~: *{}*", preamble);
 
     let indicator: String = format!("{}{}", "─".repeat(column - 1), "┘");
-    let syntax_markdown: String = format!("*├────> {}*\n*└──────{}*", text, indicator);
+    let mut syntax_skinned: String = skin.term_text("*├────> *").to_string();
+    syntax_skinned.pop(); // remove trailing newline from termimad
+    syntax_skinned.push_str(text);
+
+    let indicator_markdown: String = format!("*└──────{}*", indicator);
     sout!("{}", skin.term_text(&preamble_markdown));
-    sout!("{}", skin.term_text(&syntax_markdown));
+    soutln!("{}", syntax_skinned);
+    sout!("{}", skin.term_text(&indicator_markdown));
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,17 +52,17 @@ pub fn get_address_parts(address: &str) -> (String, String) {
 
 /// Wraps the input text in ANSI escape codes to print it in red.
 fn red_text(text: &str) -> String {
-    format!("\x1b[1;31m{}\x1b[0m", text)
+    format!("\x1b[1;31m{text}\x1b[0m")
 }
 
 /// Wraps the input text in ANSI escape codes to print it in cyan.
 fn cyan_text(text: &str) -> String {
-    format!("\x1B[36m{}\x1B[0m", text)
+    format!("\x1B[36m{text}\x1B[0m")
 }
 
 /// Wraps the input text in ANSI escape codes to print it in bold.
 fn bold_text(text: &str) -> String {
-    format!("\x1B[1m{}\x1B[0m", text)
+    format!("\x1B[1m{text}\x1B[0m")
 }
 
 /// Prints out formatted text starting with a cyan "Info:" prefix.


### PR DESCRIPTION
closes #41 

only worry I have is the `let indicator: String = format!("{}{}", "╌".repeat(column - 1), "┘");` line returning a `repeat` or 0 or -1, but I do not think that's possible with `handlebars` given that you MUST start an identifier with `{{`, which is 2 characters? so lowest we can go is 1, possibly!