### PR TITLE
standardized all args into snake_case

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,6 +123,7 @@ pub enum CliCommand {
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]
+#[clap(rename_all = "snake_case")]
 pub enum SortField {
     Proto,
     LocalPort,

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -22,6 +22,7 @@ pub struct Protocols {
 
 /// Represents a processed socket connection with all its attributes.
 #[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct Connection {
     pub proto: String,
     pub local_port: String,


### PR DESCRIPTION
kebab-case was not picked for backwards compatibility, as it would kill existing setups / pipelines; it is probably not a good idea to break previous functionality.

kebab-case would affect the `--json` output just as well, so snake_case was picked for consistency purposes

mentioned in #41 

if you decide we move forward with kebab-case let me know, however we're supposed to be on 1.0.0 version aka stable, and minor version bumps should be backwards compatible. this could be on a TODO for a 2.0.0, but it is too soon obviously.

I experimented with different serialization/deserialization cases in order to preserve existing `--json` functionality, but since everything is serialized (including the --format template names), the following had no effect:
```rust
#[serde(rename_all(serialize = "snake_case", deserialize = "kebab-case"))]
```