### PR TITLE
Add filter for established connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You can use the following flags to filter based on different attributes:
 | ```--pid``` | filter by a PID | PID number, e.g ``10000`` |
 | ```--open, -o``` | filter by open connections | - |
 | ```--listen, -l``` | filter by listening connections | - |
+| ```--established, -e``` | filter by established connections | - |
 | ```--exclude-ipv6``` | don't list IPv6 connections | - |
 
 ### ✨ Compact table view:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,7 @@ pub struct Flags {
     pub json: bool,
     pub open: bool,
     pub listen: bool,
+    pub established: bool,
     pub exclude_ipv6: bool,
     pub compact: bool,
     pub sort: Option<SortField>,
@@ -90,6 +91,10 @@ pub struct Args {
     /// Filter by listening connections
     #[arg(short = 'l', long, default_value_t = false)]
     listen: bool,
+
+    /// Filter by established connections
+    #[arg(short = 'e', long, default_value_t = false)]
+    established: bool,
 
     /// Exclude IPv6 connections
     #[arg(long, default_value_t = false)]
@@ -160,6 +165,7 @@ pub fn cli() -> CliCommand {
             json: args.json,
             open: args.open,
             listen: args.listen,
+            established: args.established,
             exclude_ipv6: args.exclude_ipv6,
             compact: args.compact,
             sort: args.sort,

--- a/src/connections/common.rs
+++ b/src/connections/common.rs
@@ -46,6 +46,9 @@ pub fn filter_out_connection(
     if filter_options.by_open && connection_details.state == "close" {
         return true;
     }
+    if filter_options.by_established && connection_details.state != "established" {
+        return true;
+    }
 
     false
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ fn main() {
         by_pid: args.pid,
         by_open: args.open,
         by_listen: args.listen,
+        by_established: args.established,
         exclude_ipv6: args.exclude_ipv6,
     };
 

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -49,6 +49,7 @@ pub struct FilterOptions {
     pub by_local_port: Option<String>,
     pub by_open: bool,
     pub by_listen: bool,
+    pub by_established: bool,
     pub exclude_ipv6: bool,
 }
 


### PR DESCRIPTION
Adds a new flag ``--established/-e`` for retrieved only "established" connections.