### PR TITLE
Refactor and standarize protocol and ip-version filtering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can use the following flags to filter based on different attributes:
 | ```--established, -e``` | filter by established connections | - |
 | ```--exclude-ipv6``` | deprecated – use ``--ipv4`` instead (mutually exclusive with ``--ipv6``) | - |
 | ```--ipv4, -4``` | filter by IPv4 connections | - |
-| ```--ipv6, -6``` | filter by IPv4 connections | - |
+| ```--ipv6, -6``` | filter by IPv6 connections | - |
 
 ### ✨ Compact table view:
 To get a smaller, more compact table use the ``--compact, -c`` flag.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ You can use the following flags to filter based on different attributes:
 | ```--open, -o``` | filter by open connections | - |
 | ```--listen, -l``` | filter by listening connections | - |
 | ```--established, -e``` | filter by established connections | - |
-| ```--exclude-ipv6``` | deprecated – use ``--ipv4`` instead (mut. exclusive with ``--ipv6``) | - |
-| ```--ipv4, -4``` | get only IPv4 connections (mut. exclusive with ``--ipv6``) | - |
-| ```--ipv6, -6``` | get only IPv6 connections (mut. exclusive with ``--ipv4``) | - |
+| ```--exclude-ipv6``` | deprecated – use ``--ipv4`` instead (mutually exclusive with ``--ipv6``) | - |
+| ```--ipv4, -4``` | filter by IPv4 connections | - |
+| ```--ipv6, -6``` | filter by IPv4 connections | - |
 
 ### ✨ Compact table view:
 To get a smaller, more compact table use the ``--compact, -c`` flag.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -292,11 +292,11 @@ pub fn resolve_protocols(args: &Flags) -> Protocols {
 
 /// Determines which IP versions to include based on CLI flags.
 ///
-/// The `--ipv4` and the deprecated `--exlude-ipv6` have the same effect
+/// The `--ipv4` and the deprecated `--exlude-ipv6` have the same effect.
 /// If no relevant flags are set, both IPv4 and IPv6 are enabled by default.
 ///
 /// # Arguments
-/// * `filter_options`: Struct representing filter options (of interest: `--ipv4`, `--ipv6`, and optionally `--exclude-ipv6`)
+/// * `args`: Parsed CLI flags (of interest: `--ipv4`, `--ipv6`, and optionally `--exclude_ipv6`)
 ///
 /// # Returns
 /// A `IpVersions` struct indicating whether to include IPv4, IPv6, or both.
@@ -304,7 +304,6 @@ pub fn resolve_ip_versions(args: &Flags) -> IpVersions {
     let ipv4 = args.ipv4 || args.exclude_ipv6;
     let ipv6 = args.ipv6;
 
-    // If neither IPv4 nor IPv6 was explicitly requested, return both as true
     if !ipv4 && !ipv6 {
         IpVersions {
             ipv4: true,

--- a/src/connections/common.rs
+++ b/src/connections/common.rs
@@ -1,4 +1,4 @@
-use crate::schemas::{AddressType, Connection, FilterOptions, IpVersions};
+use crate::schemas::{AddressType, Connection, FilterOptions};
 
 /// Checks if a connection should be filtered out based on options provided by the user.
 ///

--- a/src/connections/common.rs
+++ b/src/connections/common.rs
@@ -1,4 +1,4 @@
-use crate::schemas::{AddressType, Connection, FilterOptions};
+use crate::schemas::{AddressType, Connection, FilterOptions, IpVersions};
 
 /// Checks if a connection should be filtered out based on options provided by the user.
 ///
@@ -71,24 +71,6 @@ pub fn get_address_type(remote_address: &str) -> AddressType {
         return AddressType::Unspecified;
     }
     AddressType::Extern
-}
-
-/// Checks if just connections of a specific IP version should be fetched.
-///
-/// # Arguments
-/// * `filter_options`: The filter options containing possibly a IPv4 or IPv6 filter.
-///
-/// # Returns
-/// A tuple with three bools of which just one element can be true:
-/// * 1. element is true -> get only IPv4 connections
-/// * 3. element is true -> get only IPv6 connections
-/// * 3. element is true -> get both
-pub fn resolve_ip_version(filter_options: &FilterOptions) -> (bool, bool, bool) {
-    let ipv4_only = filter_options.by_ipv4_only || filter_options.exclude_ipv6;
-    let ipv6_only = filter_options.by_ipv6_only;
-    let take_both = !ipv4_only && !ipv6_only;
-
-    (ipv4_only, ipv6_only, take_both)
 }
 
 #[cfg(test)]
@@ -238,39 +220,5 @@ mod tests {
 
         conn.state = "close".to_string();
         assert!(filter_out_connection(&conn, &filter_by_multiple_conditions));
-    }
-
-    #[test]
-    fn test_take_ipv4_and_ipv6() {
-        let opts = FilterOptions::default();
-        assert_eq!(resolve_ip_version(&opts), (false, false, true));
-    }
-
-    #[test]
-    fn test_take_only_ipv4() {
-        let opts = FilterOptions {
-            by_ipv4_only: true,
-            ..Default::default()
-        };
-        assert_eq!(resolve_ip_version(&opts), (true, false, false));
-    }
-
-    #[test]
-    fn test_take_only_ipv6() {
-        let opts = FilterOptions {
-            by_ipv6_only: true,
-            ..Default::default()
-        };
-        assert_eq!(resolve_ip_version(&opts), (false, true, false));
-    }
-
-    #[test]
-    fn test_exclude_ipv6_means_ipv4_only() {
-        // Test for deprecated '--exclude-ipv6' flag which behaves the same as '--ipv4'
-        let opts = FilterOptions {
-            exclude_ipv6: true,
-            ..Default::default()
-        };
-        assert_eq!(resolve_ip_version(&opts), (true, false, false));
     }
 }

--- a/src/connections/linux.rs
+++ b/src/connections/linux.rs
@@ -1,4 +1,4 @@
-use crate::connections::common::{filter_out_connection, get_address_type, resolve_ip_version};
+use crate::connections::common::{filter_out_connection, get_address_type};
 use crate::schemas::{Connection, FilterOptions};
 use procfs::net::{TcpNetEntry, UdpNetEntry};
 use procfs::process::FDTarget;
@@ -135,14 +135,13 @@ fn get_tcp_connections(
 ) -> Vec<Connection> {
     let mut tcp_entries: Vec<TcpNetEntry> = Vec::new();
 
-    let (ipv4_only, ipv6_only, take_both) = resolve_ip_version(filter_options);
-
-    if take_both || ipv4_only {
+    if filter_options.by_ip_version.ipv4 {
         if let Ok(v4) = procfs::net::tcp() {
             tcp_entries.extend(v4);
         }
     }
-    if take_both || ipv6_only {
+
+    if filter_options.by_ip_version.ipv6 {
         if let Ok(v6) = procfs::net::tcp6() {
             tcp_entries.extend(v6);
         }
@@ -184,14 +183,13 @@ fn get_udp_connections(
 ) -> Vec<Connection> {
     let mut udp_entries: Vec<UdpNetEntry> = Vec::new();
 
-    let (ipv4_only, ipv6_only, take_both) = resolve_ip_version(filter_options);
-
-    if take_both || ipv4_only {
+    if filter_options.by_ip_version.ipv4 {
         if let Ok(v4) = procfs::net::udp() {
             udp_entries.extend(v4);
         }
     }
-    if take_both || ipv6_only {
+
+    if filter_options.by_ip_version.ipv6 {
         if let Ok(v6) = procfs::net::udp6() {
             udp_entries.extend(v6);
         }

--- a/src/connections/macos.rs
+++ b/src/connections/macos.rs
@@ -1,4 +1,4 @@
-use crate::connections::common::{filter_out_connection, get_address_type, resolve_ip_version};
+use crate::connections::common::{filter_out_connection, get_address_type};
 use crate::schemas::{Connection, FilterOptions};
 use libproc::libproc::proc_pid;
 use netstat2::{
@@ -106,15 +106,12 @@ fn parse_connections(
 /// # Returns
 /// All processed and filtered TCP/UDP connections as a `Connection` struct in a vector.
 pub fn get_connections(filter_options: &FilterOptions) -> Vec<Connection> {
-    let (ipv4_only, ipv6_only, _take_both) = resolve_ip_version(filter_options);
-
     let mut af_flags = AddressFamilyFlags::empty();
-    if ipv4_only {
+    if filter_options.by_ip_version.ipv4 {
         af_flags |= AddressFamilyFlags::IPV4;
-    } else if ipv6_only {
+    }
+    if filter_options.by_ip_version.ipv6 {
         af_flags |= AddressFamilyFlags::IPV6;
-    } else {
-        af_flags |= AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6;
     }
 
     let mut proto_flags = ProtocolFlags::empty();
@@ -154,7 +151,6 @@ mod tests {
         };
 
         let filter_options = FilterOptions {
-            exclude_ipv6: false,
             by_proto: Protocols {
                 tcp: true,
                 udp: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
 
     let filter_options: FilterOptions = FilterOptions {
         by_proto: cli::resolve_protocols(&args),
+        by_ip_version: cli::resolve_ip_versions(&args),
         by_remote_address: args.ip,
         by_remote_port: args.remote_port,
         by_local_port: args.port,
@@ -36,9 +37,6 @@ fn main() {
         by_open: args.open,
         by_listen: args.listen,
         by_established: args.established,
-        by_ipv4_only: args.ipv4,
-        by_ipv6_only: args.ipv6,
-        exclude_ipv6: args.exclude_ipv6,
     };
 
     let mut all_connections: Vec<Connection> = connections::get_all_connections(&filter_options);

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -20,6 +20,12 @@ pub struct Protocols {
     pub udp: bool,
 }
 
+/// Contains which type(s) of IP versions the user wants to see.
+#[derive(Debug, PartialEq, Eq, Default)]
+pub struct IpVersions {
+    pub ipv4: bool,
+    pub ipv6: bool,
+}
 /// Represents a processed socket connection with all its attributes.
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -42,6 +48,7 @@ pub struct Connection {
 #[derive(Debug, Default)]
 pub struct FilterOptions {
     pub by_proto: Protocols,
+    pub by_ip_version: IpVersions,
     pub by_program: Option<String>,
     pub by_pid: Option<String>,
     pub by_remote_address: Option<String>,
@@ -50,9 +57,6 @@ pub struct FilterOptions {
     pub by_open: bool,
     pub by_listen: bool,
     pub by_established: bool,
-    pub by_ipv4_only: bool,
-    pub by_ipv6_only: bool,
-    pub exclude_ipv6: bool,
 }
 
 /// Represents the types of network protocols.


### PR DESCRIPTION
- Refactored ip-version filtering to match implementation of protocol filtering
- Newly added ``--ipv4`` and ``--ipv6`` flags arent mutually exclusive anymore (but ``--exclude-ipv6`` and ``--ipv6`` still are).