### PR TITLE
Include Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ nix build 'github:theopfr/somo?dir=nix'
 sudo ./result/bin/somo
 ```
 
+### Homebrew:
+
+Homebrew packages a [`somo` formula](https://formulae.brew.sh/formula/somo) for macOS and Linux.
+
+```sh
+brew install somo
+```
+
 ---
 
 ## 🏃‍♀️ Running somo:


### PR DESCRIPTION
Homebrew-core has included [somo](https://github.com/Homebrew/homebrew-core/blob/main/Formula/s/somo.rb) since v1.1.0 as of 2025-07-15.

https://github.com/Homebrew/homebrew-core/commit/f6cd222d119e21d13903905545e58802f330e44b