### PR TITLE
Fix race condition in linux process enumeration

### DIFF
--- a/src/connections/linux.rs
+++ b/src/connections/linux.rs
@@ -84,7 +84,9 @@ fn get_processes() -> HashMap<u64, Stat> {
 
     let mut map: HashMap<u64, Stat> = HashMap::new();
     for p in all_procs {
-        let process = p.unwrap();
+        let Ok(process) = p else {
+            continue;
+        };
 
         if let (Ok(stat), Ok(fds)) = (process.stat(), process.fd()) {
             for fd in fds {


### PR DESCRIPTION
I recently got this issue when running somo:

```
thread 'main' (292636) panicked at src/connections/linux.rs:87:25:
called `Result::unwrap()` on an `Err` value: NotFound(Some("/proc/292637"))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After looking through the code it seems like a race condition that happens when a process exits at just the right time.

This is a fairly crude fix, but it does work.