### PR TITLE
chore: remove redundant references to calm clippy

### DIFF
--- a/src/connections/linux.rs
+++ b/src/connections/linux.rs
@@ -145,7 +145,7 @@ fn get_tcp_connections(
 
     if filter_options.by_ip_version.ipv4 {
         if let Ok(v4) =
-            TcpNetEntries::from_file(format!("{}/net/tcp", &*PROCFS_ROOT), current_system_info())
+            TcpNetEntries::from_file(format!("{}/net/tcp", *PROCFS_ROOT), current_system_info())
                 .map(|e| e.0)
         {
             tcp_entries.extend(v4);
@@ -154,7 +154,7 @@ fn get_tcp_connections(
 
     if filter_options.by_ip_version.ipv6 {
         if let Ok(v6) =
-            TcpNetEntries::from_file(format!("{}/net/tcp6", &*PROCFS_ROOT), current_system_info())
+            TcpNetEntries::from_file(format!("{}/net/tcp6", *PROCFS_ROOT), current_system_info())
                 .map(|e| e.0)
         {
             tcp_entries.extend(v6);
@@ -199,7 +199,7 @@ fn get_udp_connections(
 
     if filter_options.by_ip_version.ipv4 {
         if let Ok(v4) =
-            UdpNetEntries::from_file(format!("{}/net/udp", &*PROCFS_ROOT), current_system_info())
+            UdpNetEntries::from_file(format!("{}/net/udp", *PROCFS_ROOT), current_system_info())
                 .map(|e| e.0)
         {
             udp_entries.extend(v4);
@@ -208,7 +208,7 @@ fn get_udp_connections(
 
     if filter_options.by_ip_version.ipv6 {
         if let Ok(v6) =
-            UdpNetEntries::from_file(format!("{}/net/udp6", &*PROCFS_ROOT), current_system_info())
+            UdpNetEntries::from_file(format!("{}/net/udp6", *PROCFS_ROOT), current_system_info())
                 .map(|e| e.0)
         {
             udp_entries.extend(v6);

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -188,7 +188,7 @@ impl Table {
 
 impl fmt::Display for Table {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", &self.content)
+        write!(f, "{}", self.content)
     }
 }
 


### PR DESCRIPTION
All dependabot PRs are blocked because clippy is faling (new rules added to clippy appearently, and we are using `stable` version).