### PR TITLE
Add connection filtering by user

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ termimad = "0.35.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 handlebars = "6.4.1"
-nix = {version = "0.31.3", features = ["process", "signal"]}
+nix = {version = "0.31.3", features = ["process", "signal", "user"]}
 etcetera = "0.11.0"
 libc = "0.2.186"
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Options:
   -p, --port <PORT>                Filter connections by local port
       --program <PROGRAM>          Filter connections by program name
       --pid <PID>                  Filter connections by PID
+      --user <USER>                Filter connections by username
       --format <FORMAT>            Format the output in a certain way, e.g., `somo --format "PID: {{pid}}, Protocol: {{proto}}, Remote Address: {{remote_address}}"`
       --json                       Output in JSON
   -o, --open                       Filter by open connections
@@ -132,6 +133,7 @@ You can use the following flags to filter based on different attributes:
 | ```--ip``` | filter by a remote IP | IP address e.g ``0.0.0.0`` |
 | ```--program``` | filter by a client program | program name e.g ``chrome`` |
 | ```--pid``` | filter by a PID | PID number, e.g ``10000`` |
+| ```--user``` | filter by the user that owns a connection | username, e.g ``root`` |
 | ```--open, -o``` | filter by open connections | - |
 | ```--listen, -l``` | filter by listening connections | - |
 | ```--established, -e``` | filter by established connections | - |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap_complete::{generate, Generator, Shell};
 use inquire::InquireError;
 use inquire::Select;
 use nix::sys::signal;
-use nix::unistd::Pid;
+use nix::unistd::{Pid, User};
 use std::env;
 use std::str::FromStr;
 use std::{io, string::String};
@@ -26,6 +26,7 @@ pub struct Flags {
     pub port: Option<String>,
     pub program: Option<String>,
     pub pid: Option<String>,
+    pub user: Option<u32>,
     pub format: Option<String>,
     pub json: bool,
     pub open: bool,
@@ -84,6 +85,15 @@ pub struct Args {
     /// Filter connections by PID
     #[arg(long, default_value = None, overrides_with = "pid")]
     pid: Option<String>,
+
+    /// Filter connections by username
+    #[arg(
+        long,
+        value_name = "USER",
+        value_parser = parse_user,
+        overrides_with = "user"
+    )]
+    user: Option<u32>,
 
     /// Format the output in a certain way, e.g., `somo --format "PID: {{pid}}, Protocol: {{proto}}, Remote Address: {{remote_address}}"`
     #[arg(long, default_value = None, overrides_with = "format")]
@@ -179,6 +189,21 @@ pub enum CliCommand {
     Subcommand(Commands),
 }
 
+/// Resolves a username to its numeric user ID for the `--user` flag.
+///
+/// # Arguments
+/// * `name`: The username as passed on the command line.
+///
+/// # Returns
+/// The user ID or an error message if the user couldn't be resolved.
+fn parse_user(name: &str) -> Result<u32, String> {
+    match User::from_name(name) {
+        Ok(Some(user)) => Ok(user.uid.as_raw()),
+        Ok(None) => Err(format!("unknown user '{name}'")),
+        Err(error) => Err(format!("failed to resolve user '{name}': {error}")),
+    }
+}
+
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]
 #[clap(rename_all = "snake_case")]
 pub enum SortField {
@@ -216,6 +241,7 @@ pub fn cli() -> CliCommand {
             port: args.port,
             program: args.program,
             pid: args.pid,
+            user: args.user,
             format: args.format,
             json: args.json,
             open: args.open,
@@ -415,6 +441,8 @@ mod tests {
             "nginx",
             "--pid",
             "1234",
+            "--user",
+            "root",
             "-o",
             "-l",
             "--exclude-ipv6",
@@ -430,6 +458,7 @@ mod tests {
         assert_eq!(args.port.as_deref(), Some("8080"));
         assert_eq!(args.program.as_deref(), Some("nginx"));
         assert_eq!(args.pid.as_deref(), Some("1234"));
+        assert_eq!(args.user, Some(0));
         assert!(args.open);
         assert!(args.listen);
         assert!(args.ipv4);
@@ -450,6 +479,7 @@ mod tests {
         assert!(args.port.is_none());
         assert!(args.program.is_none());
         assert!(args.pid.is_none());
+        assert!(args.user.is_none());
         assert!(!args.open);
         assert!(!args.listen);
         assert!(!args.exclude_ipv6);
@@ -468,6 +498,17 @@ mod tests {
         assert_eq!(short.open, long.open);
         assert_eq!(short.listen, long.listen);
         assert_eq!(short.exclude_ipv6, long.exclude_ipv6);
+    }
+
+    #[test]
+    fn test_user_filter_does_not_conflict_with_udp_short_flag() {
+        let udp = Args::parse_from(["test-bin", "-u"]);
+        let user = Args::parse_from(["test-bin", "--user", "root"]);
+
+        assert!(udp.udp);
+        assert!(udp.user.is_none());
+        assert_eq!(user.user, Some(0));
+        assert!(!user.udp);
     }
 
     #[test]

--- a/src/connections/common.rs
+++ b/src/connections/common.rs
@@ -53,6 +53,13 @@ pub fn filter_out_connection(
     false
 }
 
+pub fn filter_out_user(connection_user_id: Option<u32>, filter_user_id: Option<u32>) -> bool {
+    matches!(
+        filter_user_id,
+        Some(filter_user_id) if connection_user_id != Some(filter_user_id)
+    )
+}
+
 /// Checks if a given IP address is either "unspecified", localhost or an extern address.
 ///
 /// * `0.0.0.0` or `[::]` -> unspecified
@@ -188,6 +195,14 @@ mod tests {
             ..Default::default()
         };
         assert!(filter_out_connection(&conn, &no_active_open_filter));
+    }
+
+    #[test]
+    fn test_filter_out_connection_by_user() {
+        assert!(!filter_out_user(Some(1000), Some(1000)));
+        assert!(filter_out_user(Some(1000), Some(2000)));
+        assert!(filter_out_user(None, Some(1000)));
+        assert!(!filter_out_user(Some(1000), None));
     }
 
     #[test]

--- a/src/connections/linux.rs
+++ b/src/connections/linux.rs
@@ -1,4 +1,4 @@
-use crate::connections::common::{filter_out_connection, get_address_type};
+use crate::connections::common::{filter_out_connection, filter_out_user, get_address_type};
 use crate::schemas::{Connection, FilterOptions};
 use procfs::net::{TcpNetEntries, TcpNetEntry, UdpNetEntries, UdpNetEntry};
 use procfs::process::FDTarget;
@@ -164,6 +164,10 @@ fn get_tcp_connections(
     tcp_entries
         .iter()
         .filter_map(|entry| {
+            if filter_out_user(Some(entry.uid), filter_options.by_user) {
+                return None;
+            }
+
             let tcp_entry: NetEntry = NetEntry {
                 protocol: "tcp".to_string(),
                 local_address: entry.local_address,
@@ -218,6 +222,10 @@ fn get_udp_connections(
     udp_entries
         .iter()
         .filter_map(|entry| {
+            if filter_out_user(Some(entry.uid), filter_options.by_user) {
+                return None;
+            }
+
             let udp_entry: NetEntry = NetEntry {
                 protocol: "udp".to_string(),
                 local_address: entry.local_address,

--- a/src/connections/macos.rs
+++ b/src/connections/macos.rs
@@ -1,5 +1,6 @@
-use crate::connections::common::{filter_out_connection, get_address_type};
+use crate::connections::common::{filter_out_connection, filter_out_user, get_address_type};
 use crate::schemas::{Connection, FilterOptions};
+use libproc::libproc::bsd_info::BSDInfo;
 use libproc::libproc::proc_pid;
 use netstat2::{
     get_sockets_info, AddressFamilyFlags, ProtocolFlags, ProtocolSocketInfo as NetstatSocketInfo,
@@ -19,6 +20,12 @@ fn get_process_name(pid: i32) -> String {
         Ok(name) => name,
         Err(_) => "-".to_string(),
     }
+}
+
+fn get_process_user_id(pid: i32) -> Option<u32> {
+    proc_pid::pidinfo::<BSDInfo>(pid, 0)
+        .ok()
+        .map(|info| info.pbi_uid)
 }
 
 /// Parses and filters TCP and/or UDP connections using socket information.
@@ -63,11 +70,14 @@ fn parse_connections(
                     ),
                 };
 
-            let (program, pid) = if let Some(first_pid) = si.associated_pids.first() {
+            let (program, pid, user_id) = if let Some(first_pid) = si.associated_pids.first() {
                 let proc_name = get_process_name(*first_pid as i32);
-                (proc_name, first_pid.to_string())
+                let user_id = filter_options
+                    .by_user
+                    .and_then(|_| get_process_user_id(*first_pid as i32));
+                (proc_name, first_pid.to_string(), user_id)
             } else {
-                ("-".to_string(), "-".to_string())
+                ("-".to_string(), "-".to_string(), None)
             };
 
             // Create a unique key for deduplication
@@ -76,6 +86,10 @@ fn parse_connections(
 
             // If the connection has already been processed, skip it
             if !seen_connections.insert(connection_key) {
+                return None;
+            }
+
+            if filter_out_user(user_id, filter_options.by_user) {
                 return None;
             }
 
@@ -138,6 +152,14 @@ mod tests {
     use crate::schemas::Protocols;
     use netstat2::{ProtocolSocketInfo, SocketInfo, TcpSocketInfo, TcpState};
     use std::net::{IpAddr, Ipv4Addr};
+
+    #[test]
+    fn test_get_process_user_id_for_current_process() {
+        assert_eq!(
+            get_process_user_id(std::process::id() as i32),
+            Some(nix::unistd::Uid::current().as_raw())
+        );
+    }
 
     #[test]
     fn test_parse_connections_tcp() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
         by_remote_address: args.ip,
         by_remote_port: args.remote_port,
         by_local_port: args.port,
+        by_user: args.user,
         by_program: args.program,
         by_pid: args.pid,
         by_open: args.open,

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -49,6 +49,7 @@ pub struct Connection {
 pub struct FilterOptions {
     pub by_proto: Protocols,
     pub by_ip_version: IpVersions,
+    pub by_user: Option<u32>,
     pub by_program: Option<String>,
     pub by_pid: Option<String>,
     pub by_remote_address: Option<String>,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -264,6 +264,22 @@ mod test_connection_data {
     }
 
     #[test]
+    fn test_user_filter() {
+        let mut cmd = base_exec_json();
+        cmd.arg("--user").arg("root"); // Mock socket entries are owned by UID 0
+        let stdout = get_stdout(cmd);
+
+        let connections: Vec<Connection> =
+            serde_json::from_str(&stdout).expect("Failed to parse JSON.");
+
+        assert_eq!(
+            connections.len(),
+            NUM_PROCESSES,
+            "Expected to receive all root-owned connections."
+        );
+    }
+
+    #[test]
     fn test_open_state_filter() {
         let mut cmd = base_exec_json();
         cmd.arg("--open");


### PR DESCRIPTION
## Summary

- add a `--user <USER>` filter that resolves usernames through the system user database
- filter socket ownership via `/proc/net` UIDs on Linux and process effective UIDs on macOS without changing the output schema
- preserve `-u` as the existing `--udp` shorthand

## Testing

- `cargo test` (44 unit tests plus doc tests)
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo check --tests --target x86_64-unknown-linux-gnu`
- manual macOS listener check for matching and non-matching users

Closes #176
